### PR TITLE
marlin: Set OPA property to enable google assistant

### DIFF
--- a/device-lineage.mk
+++ b/device-lineage.mk
@@ -1,3 +1,6 @@
+# Google Assistant
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.opa.eligible_device=true
+
 # IMS
 PRODUCT_PACKAGES += \
     com.android.ims.rcsmanager \


### PR DESCRIPTION
Stock pixel roms before Pie had this property in
/vendor/build.prop so we never needed this change since
we use google's vendor img. With Pie it was moved to
/system/etc/prop.default, so we need to set it now.

Change-Id: I741171219d64a28d56531f063f95f3f6f6cf81e6